### PR TITLE
Fix filter plugin lookup logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IntelliJ PyCharm
+.idea/

--- a/add_docs.py
+++ b/add_docs.py
@@ -111,7 +111,7 @@ def update_readme(content, path, gh_url):
             else:
                 link = plugin
             data.append(
-                "{link}|{description}".format(link=link, description=description)
+                "{link}|{description}".format(link=link, description=description.replace('|', '\\|'))
             )
     readme = os.path.join(path, "README.md")
     try:
@@ -189,13 +189,14 @@ def handle_filters(collection, fullpath):
     filter_map = dict(zip(keys, values))
     for name, func in filter_map.items():
         if func in function_definitions:
-            comment = function_definitions[func] or ""
-            comment = [
-                c for c in comment.splitlines() if c and not c.startswith(":")
-            ]
+            comment = function_definitions[func] or \
+                        "{collection} {name} filter plugin".format(collection=collection, name=name)
+
+            # Get the first line from the docstring for the description and make that the short description.
+            comment = next(c for c in comment.splitlines() if c and not c.startswith(":"))
             plugins[
                 "{collection}.{name}".format(collection=collection, name=name)
-            ] = " ".join(comment)
+            ] = comment
     return plugins
 
 

--- a/add_docs.py
+++ b/add_docs.py
@@ -160,28 +160,42 @@ def handle_filters(collection, fullpath):
         for node in module.body
         if isinstance(node, ast.ClassDef) and node.name == "FilterModule"
     ]
-    if classdef:
-        assign = [
-            node
-            for node in classdef[0].body
-            if isinstance(node, ast.Assign)
-            and hasattr(node, "targets")
-            and node.targets[0].id == "filter_map"
-        ]
-        if assign:
-            keys = [k.value for k in assign[0].value.keys]
-            logging.info("Adding filter plugins %s", ",".join(keys))
-            values = [k.id for k in assign[0].value.values]
-            filter_map = dict(zip(keys, values))
-            for name, func in filter_map.items():
-                if func in function_definitions:
-                    comment = function_definitions[func] or ""
-                    comment = [
-                        c for c in comment.splitlines() if c and not c.startswith(":")
-                    ]
-                    plugins[
-                        "{collection}.{name}".format(collection=collection, name=name)
-                    ] = " ".join(comment)
+    if not classdef:
+        return plugins
+
+    filter_func = [
+        func
+        for func in classdef[0].body
+        if isinstance(func, ast.FunctionDef)
+        and func.name == 'filters'
+    ]
+    if not filter_func:
+        return plugins
+
+    # The filter map is either looked up using the filter_map = {} assignment or if return returns a dict literal.
+    filter_map = next((
+        node
+        for node in filter_func[0].body if
+        (isinstance(node, ast.Assign) and hasattr(node, "targets") and node.targets[0].id == "filter_map") or
+        (isinstance(node, ast.Return) and isinstance(node.value, ast.Dict))
+    ), None)
+
+    if not filter_map:
+        return plugins
+
+    keys = [k.value for k in filter_map.value.keys]
+    logging.info("Adding filter plugins %s", ",".join(keys))
+    values = [k.id for k in filter_map.value.values]
+    filter_map = dict(zip(keys, values))
+    for name, func in filter_map.items():
+        if func in function_definitions:
+            comment = function_definitions[func] or ""
+            comment = [
+                c for c in comment.splitlines() if c and not c.startswith(":")
+            ]
+            plugins[
+                "{collection}.{name}".format(collection=collection, name=name)
+            ] = " ".join(comment)
     return plugins
 
 


### PR DESCRIPTION
I'm not sure how the original logic was mean to lookup filter plugins but the changes made here will find the plugin mapping based on the standard [ansible/ansible core.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/filter/core.py).

This code will find the lookup plugin first by seeing if `filter_map` is defined in the `filters()` function of `FilterModule`, or if that isn't present then seeing if `filters()` returns a dict literal like:

```python
class FilterModule:

    def filters(self):
        filter_map = {
            'filter_name': filter_func,
        }
        return filter_map
```

or

```python
class FilterModule:

    def filters(self):
        return {
            'filter_name': filter_func,
        }
```

This PR also escapes `|` when generating the markdown table to avoid the text being cut off.

Finally it also tries to reduce the amount of text generated for the filter plugins description field. It will only return the first line in the functions docstring, similar to how modules have a short description. I feel like this stops the README from being cluttered but if you wish to go back to the original behaviour we can.

An example of this short description change for the `ansible.windows quote` filter plugin that has the following function docstring

```python
def quote(value, shell=None):
    """Quotes argument(s) for the various shells in Windows command processing.

    Quotes argument(s) for the various Windows command line shells. Default to escaping arguments based on the Win32 C
    argv parsing rules that 'win_command' uses but shell='cmd' or shell='powershell' can be set to escape arguments for
    those respective shells. Each value is escaped in a way to ensure the process gets the literal argument passed in
    and meta chars escaped.

    When passing in a dict, the arguments will be in the form 'key={{ value | ansible.windows.quote }}' to match the
    MSI parameter format.

    :params value: A string, list, or dict of value(s) to quote.
    :params shell: The shell that is used to escape the args for.
    :return: The quoted argument(s) from the input.
    """
    ....
    return
```

```markdown
# Before
## Filter plugins
Name | Description
--- | ---
ansible.windows.quote|Quotes argument(s) for the various shells in Windows command processing. Quotes argument(s) for the various Windows command line shells. Default to escaping arguments based on the Win32 C argv parsing rules that 'win_command' uses but shell='cmd' or shell='powershell' can be set to escape arguments for those respective shells. Each value is escaped in a way to ensure the process gets the literal argument passed in and meta chars escaped. When passing in a dict, the arguments will be in the form 'key={{ value \| ansible.windows.quote }}' to match the MSI parameter format.

# After
## Filter plugins
Name | Description
--- | ---
ansible.windows.quote|Quotes argument(s) for the various shells in Windows command processing.
```