### PR TITLE
Set plugin_type in doc template

### DIFF
--- a/add_docs.py
+++ b/add_docs.py
@@ -206,9 +206,9 @@ def process(collection, path):  # pylint: disable-msg=too-many-locals
 
     for subdir in SUBDIRS:
         if subdir == "modules":
-            doc_key = "module"
+            plugin_type = "module"
         else:
-            doc_key = subdir
+            plugin_type = subdir
 
         dirpath = Path(path, "plugins", subdir)
         if dirpath.is_dir():
@@ -225,6 +225,8 @@ def process(collection, path):  # pylint: disable-msg=too-many-locals
                             fullpath, fragment_loader
                         )
                         if doc:
+                            doc['plugin_type'] = plugin_type
+
                             if returndocs:
                                 doc["returndocs"] = yaml.safe_load(returndocs)
                                 convert_descriptions(doc["returndocs"])
@@ -236,7 +238,7 @@ def process(collection, path):  # pylint: disable-msg=too-many-locals
                                 doc["examples"] = examples
 
                             doc["module"] = "{collection}.{plugin_name}".format(
-                                collection=collection, plugin_name=doc[doc_key]
+                                collection=collection, plugin_name=doc[plugin_type]
                             )
                             doc["author"] = ensure_list(doc["author"])
                             doc["description"] = ensure_list(doc["description"])


### PR DESCRIPTION
Set the `plugin_type` key in the templated vars so the templated rst follows the same standard we use for docs.ansible.com.

The biggest difference is that with this change the module docs no longer have the `Configurations` column which is not used by modules. Here is an example of what it looks like before the change

![image](https://user-images.githubusercontent.com/8462645/83314276-0e12e900-a25d-11ea-8da1-9f220f752e86.png)

and after this change

![image](https://user-images.githubusercontent.com/8462645/83314300-1ec35f00-a25d-11ea-8809-8edc0de0e283.png)