### PR TITLE
Update add docs

### DIFF
--- a/add_docs.py
+++ b/add_docs.py
@@ -24,6 +24,7 @@ from jinja_utils import (
     documented_type,
 )
 
+
 logging.basicConfig(format="%(levelname)-10s%(message)s", level=logging.INFO)
 
 
@@ -42,6 +43,7 @@ def ensure_list(value):
     if isinstance(value, list):
         return value
     return [value]
+
 
 def convert_descriptions(data):
     """ Convert the descriptions for doc into lists
@@ -111,7 +113,9 @@ def update_readme(content, path, gh_url):
             else:
                 link = plugin
             data.append(
-                "{link}|{description}".format(link=link, description=description.replace('|', '\\|'))
+                "{link}|{description}".format(
+                    link=link, description=description.replace("|", "\\|")
+                )
             )
     readme = os.path.join(path, "README.md")
     try:
@@ -136,7 +140,7 @@ def update_readme(content, path, gh_url):
 
 
 def handle_filters(collection, fullpath):
-    """ Grab each filter from a filter plugin file and 
+    """ Grab each filter from a filter plugin file and
     use the def comment if available
 
     :param collection: The full collection name
@@ -166,19 +170,25 @@ def handle_filters(collection, fullpath):
     filter_func = [
         func
         for func in classdef[0].body
-        if isinstance(func, ast.FunctionDef)
-        and func.name == 'filters'
+        if isinstance(func, ast.FunctionDef) and func.name == "filters"
     ]
     if not filter_func:
         return plugins
 
     # The filter map is either looked up using the filter_map = {} assignment or if return returns a dict literal.
-    filter_map = next((
-        node
-        for node in filter_func[0].body if
-        (isinstance(node, ast.Assign) and hasattr(node, "targets") and node.targets[0].id == "filter_map") or
-        (isinstance(node, ast.Return) and isinstance(node.value, ast.Dict))
-    ), None)
+    filter_map = next(
+        (
+            node
+            for node in filter_func[0].body
+            if (
+                isinstance(node, ast.Assign)
+                and hasattr(node, "targets")
+                and node.targets[0].id == "filter_map"
+            )
+            or (isinstance(node, ast.Return) and isinstance(node.value, ast.Dict))
+        ),
+        None,
+    )
 
     if not filter_map:
         return plugins
@@ -189,11 +199,16 @@ def handle_filters(collection, fullpath):
     filter_map = dict(zip(keys, values))
     for name, func in filter_map.items():
         if func in function_definitions:
-            comment = function_definitions[func] or \
-                        "{collection} {name} filter plugin".format(collection=collection, name=name)
+            comment = function_definitions[
+                func
+            ] or "{collection} {name} filter plugin".format(
+                collection=collection, name=name
+            )
 
             # Get the first line from the docstring for the description and make that the short description.
-            comment = next(c for c in comment.splitlines() if c and not c.startswith(":"))
+            comment = next(
+                c for c in comment.splitlines() if c and not c.startswith(":")
+            )
             plugins[
                 "{collection}.{name}".format(collection=collection, name=name)
             ] = comment
@@ -240,7 +255,7 @@ def process(collection, path):  # pylint: disable-msg=too-many-locals
                             fullpath, fragment_loader
                         )
                         if doc:
-                            doc['plugin_type'] = plugin_type
+                            doc["plugin_type"] = plugin_type
 
                             if returndocs:
                                 doc["returndocs"] = yaml.safe_load(returndocs)

--- a/plugin.rst.j2
+++ b/plugin.rst.j2
@@ -38,7 +38,7 @@ Version added: @{ version_added | default('') }@
 DEPRECATED
 ----------
 {# use unknown here? skip the fields? #}
-:Removed in Ansible: version: @{ deprecated['removed_in'] | default('') | string | rst_ify }@
+:Removed in collection release after @{ deprecated['removed_at_date'] | default('') | string | rst_ify }@
 :Why: @{ deprecated['why'] | default('') | rst_ify }@
 :Alternative: @{ deprecated['alternative'] | default('') | rst_ify }@
 

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,7 @@ def get_removed_at_date():
         depcrecation_month = today.month
 
     depcrecation_date = (
-        f"{deprecation_year}-{depcrecation_month}-{REMOVAL_DAY_OF_MONTH}"
+        f"{deprecation_year}-{depcrecation_month:02d}-{REMOVAL_DAY_OF_MONTH}"
     )
 
     return depcrecation_date


### PR DESCRIPTION
`add_docs` was falling over on `ansible.netcommon`'s filter plugins. I tried to change it to how it seemed to be intended to be used.

I also updated the doc template to show deprecations as versions, and updated `get_removed_at_date()` to always return ISO 8601 dates.

Also Black.