### PR TITLE
Fix with devel and remove config hint

### DIFF
--- a/add_docs.py
+++ b/add_docs.py
@@ -282,7 +282,11 @@ def process(collection, path):  # pylint: disable-msg=too-many-locals
                             doc["plugin_type"] = plugin_type
 
                             if returndocs:
-                                doc["returndocs"] = yaml.safe_load(returndocs)
+                                # Seems a recent change in devel makes this return a dict not a yaml string.
+                                if isinstance(returndocs, dict):
+                                    doc["returndocs"] = returndocs
+                                else:
+                                    doc["returndocs"] = yaml.safe_load(returndocs)
                                 convert_descriptions(doc["returndocs"])
 
                             doc["metadata"] = (metadata,)

--- a/plugin.rst.j2
+++ b/plugin.rst.j2
@@ -422,7 +422,9 @@ Authors
 - @{ author_name }@
 {%   endfor %}
 
+{% endif %}
 
+{% if plugin_type != 'module' %}
 .. hint::
     Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.
 {% endif %}


### PR DESCRIPTION
When attempting to run `add_docs.py` on the current devel version it fails with the traceback

```
Traceback (most recent call last):                                                                                                                                                                                 
  File "add_docs.py", line 446, in <module>                                                                                                                                                                        
    main()                                                                                                                                                                                                         
  File "add_docs.py", line 439, in main                                                                                                                                                                            
    content = process(collection=collection, path=path)                                                  
  File "add_docs.py", line 285, in process                                                               
    doc["returndocs"] = yaml.safe_load(returndocs)                                                       
  File "/home/jborean/venvs/ansible-py38/lib/python3.8/site-packages/yaml/__init__.py", line 162, in safe_load
    return load(stream, SafeLoader)                                                                      
  File "/home/jborean/venvs/ansible-py38/lib/python3.8/site-packages/yaml/__init__.py", line 112, in load
    loader = Loader(stream)                                                                              
  File "/home/jborean/venvs/ansible-py38/lib/python3.8/site-packages/yaml/loader.py", line 34, in __init__
    Reader.__init__(self, stream)                                                                        
  File "/home/jborean/venvs/ansible-py38/lib/python3.8/site-packages/yaml/reader.py", line 85, in __init__
    self.determine_encoding()                                                                                                                                                                                      
  File "/home/jborean/venvs/ansible-py38/lib/python3.8/site-packages/yaml/reader.py", line 124, in determine_encoding
    self.update_raw()                                                                                    
  File "/home/jborean/venvs/ansible-py38/lib/python3.8/site-packages/yaml/reader.py", line 178, in update_raw
    data = self.stream.read(size)                                                                        
AttributeError: 'AnsibleMapping' object has no attribute 'read'    
```

It looks like that `returndocs` is now a dict potentially caused by https://github.com/ansible/ansible/commit/8d93ba91208ca5a0d2919acb1a5697e71f64d2f9. This just adds a check to skip loading it through yaml if it was already a dict.

Also removes the hint for module docs below as they do not have configuration entires.

```
.. hint::
    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.
```