### PR TITLE
Also generate lookup plugin docs

### DIFF
--- a/add_docs.py
+++ b/add_docs.py
@@ -35,6 +35,7 @@ SUBDIRS = (
     "connection",
     "filter",
     "httpapi",
+    "lookup",
     "netconf",
     "modules",
 )


### PR DESCRIPTION
Not sure why these were excluded on purpose or just forgotten but I need to be able to document on lookup plugins in a collection.