### PR TITLE
Give option to specify the branch name, fix relative path handling

### DIFF
--- a/plugin.rst.j2
+++ b/plugin.rst.j2
@@ -61,7 +61,7 @@ Requirements
 {%   if plugin_type == 'module' %}
 The below requirements are needed on the host that executes this @{ plugin_type }@.
 {%   else %}
-The below requirements are needed on the local master node that executes this @{ plugin_type }@.
+The below requirements are needed on the local Ansible controller node that executes this @{ plugin_type }@.
 {%   endif %}
 
 {%   for req in requirements %}


### PR DESCRIPTION
* Allows someone to override the branch name used when creating the doc path in the README
* Updates the `TEMPLATE_DIR` to be relative to the script itself and not the cwd
* Updates the plugin template to not use the term master but Ansible controller