### PR TITLE
Updates to add_docs to address whitespace errors in generated docs

### DIFF
--- a/add_docs.py
+++ b/add_docs.py
@@ -309,7 +309,7 @@ def process(collection, path):  # pylint: disable-msg=too-many-locals
 
                             doc["metadata"] = (metadata,)
                             if isinstance(examples, string_types):
-                                doc["plainexamples"] = examples
+                                doc["plainexamples"] = examples.strip()
                             else:
                                 doc["examples"] = examples
 

--- a/add_docs.py
+++ b/add_docs.py
@@ -166,6 +166,10 @@ def update_readme(content, path, gh_url, branch_name):
         new = content[0 : start + 1] + data + content[end:]
         with open(readme, "w") as fhand:
             fhand.write("\n".join(new))
+            # Avoid "No newline at end of file.
+            # No, I don't know why it has to be two of them.
+            # Yes, it actually does have to be two of them.
+            fhand.write("\n\n")
         logging.info("README.md updated")
 
 

--- a/add_docs.py
+++ b/add_docs.py
@@ -96,6 +96,7 @@ def jinja_environment():
         loader=FileSystemLoader(TEMPLATE_DIR),
         variable_start_string="@{",
         variable_end_string="}@",
+        lstrip_blocks=True,
         trim_blocks=True,
     )
     env.filters["rst_ify"] = rst_ify

--- a/plugin.rst.j2
+++ b/plugin.rst.j2
@@ -421,10 +421,10 @@ Authors
 {%   for author_name in author %}
 - @{ author_name }@
 {%   endfor %}
-
 {% endif %}
-
 {% if plugin_type != 'module' %}
+
+
 .. hint::
     Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.
 {% endif %}


### PR DESCRIPTION
* `lstrip_blocks` and `examples.strip()` address empty lines with trailing whitespace.
* `fhand.write("\n\n")` ensures that README.rst is generated with a newline at the end of the file.
* The whitespace changes in plugin.rst.j2 avoid trailing newlines in modules, while retaining the separation for the note in non-modules