### PR TITLE
Fix some whitespace issues introduced in #30

### DIFF
--- a/plugin.rst.j2
+++ b/plugin.rst.j2
@@ -90,7 +90,7 @@ Parameters
                 {% endif -%}
             {% endif -%}
         {% endfor -%}
-        {# Header of the documentation -#}
+        {# Header of the documentation #}
         <tr>
             <th colspan="@{ from_kludge_ns('maxdepth') }@">Parameter</th>
             <th>Choices/<font color="blue">Defaults</font></th>
@@ -112,10 +112,16 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">@{ value.type | documented_type }@</span>
-                        {% if value.get('elements') %} / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>{% endif %}
-                        {% if value.get('required', False) %} / <span style="color: red">required</span>{% endif %}
+                        {% if value.get('elements') %}
+                         / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>
+                        {% endif %}
+                        {% if value.get('required', False) %}
+                         / <span style="color: red">required</span>
+                        {% endif %}
                     </div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>
+                    {% endif %}
                 </td>
                 {# default / choices #}
                 <td>
@@ -288,9 +294,13 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                     <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this fact"></a>
                     <div style="font-size: small">
                       <span style="color: purple">@{ value.type | documented_type }@</span>
-                      {% if value.elements %} / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>{% endif %}
+                      {% if value.elements %}
+                       / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>
+                      {% endif %}
                     </div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>
+                    {% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>
@@ -365,7 +375,9 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value"></a>
                     <div style="font-size: small">
                       <span style="color: purple">@{ value.type | documented_type }@</span>
-                      {% if value.elements %} / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>{% endif %}
+                      {% if value.elements %}
+                       / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>
+                      {% endif %}
                     </div>
                     {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
                 </td>


### PR DESCRIPTION
`lstrip_blocks` also has the side effect of stripping the lefthand side of inline {% if %}s if there is only whitespace preceding them.

This uninlines those conditionals.