### PR TITLE
use inventory plugins in collection_prep_update

### DIFF
--- a/collection_prep/cmd/update.py
+++ b/collection_prep/cmd/update.py
@@ -24,6 +24,7 @@ SUBDIRS = (
     "httpapi",
     "netconf",
     "terminal",
+    "inventory",
 )
 SPECIALS = {"ospfv2": "OSPFv2", "interfaces": "Interfaces", "static": "Static"}
 


### PR DESCRIPTION
collection_prep_add_docs already handles inventory plugins, but collection_prep_update does not. This change enables collection_prep_update to handle inventory plugins.