### PR TITLE
Examples to yaml only

### DIFF
--- a/collection_prep/cmd/plugin.rst.j2
+++ b/collection_prep/cmd/plugin.rst.j2
@@ -242,7 +242,7 @@ See Also
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
 {%   for example in examples %}
 {%     if example['description'] %}@{ example['description'] | indent(4, True) }@{% endif %}


### PR DESCRIPTION
GH doesn't syntax high light yaml+jinja, so we'll try yaml only