### PR TITLE
Add filter support

### DIFF
--- a/collection_prep/cmd/runtime.py
+++ b/collection_prep/cmd/runtime.py
@@ -10,7 +10,11 @@ import glob
 from argparse import ArgumentParser
 
 import ruamel.yaml
-from collection_prep.utils import get_removed_at_date, load_py_as_ast, find_assigment_in_ast
+from collection_prep.utils import (
+    get_removed_at_date,
+    load_py_as_ast,
+    find_assigment_in_ast,
+)
 
 logging.basicConfig(format="%(levelname)-10s%(message)s", level=logging.INFO)
 
@@ -50,7 +54,9 @@ def process_runtime_plugin_routing(collection, path):
         )
 
         ast_obj = load_py_as_ast(fullpath)
-        documentation = find_assigment_in_ast(ast_file=ast_obj, name="DOCUMENTATION")
+        documentation = find_assigment_in_ast(
+            ast_file=ast_obj, name="DOCUMENTATION"
+        )
         doc_section = ruamel.yaml.load(
             documentation.value.to_python(), ruamel.yaml.RoundTripLoader
         )
@@ -67,7 +73,9 @@ def process_runtime_plugin_routing(collection, path):
         # by design will invoke action plugin first.
         if not os.path.exists(os.path.join(action_path, f"{module_name}.py")):
             if (
-                os.path.exists(os.path.join(action_path, f"{module_prefix}.py"))
+                os.path.exists(
+                    os.path.join(action_path, f"{module_prefix}.py")
+                )
                 and module_prefix == collection_name
             ):
                 fq_action_name = f"{collection}.{module_prefix}"
@@ -88,7 +96,9 @@ def process_runtime_plugin_routing(collection, path):
             fq_module_name = f"{collection}.{module_name}"
             if not plugin_routing.get("modules"):
                 plugin_routing["modules"] = {}
-            plugin_routing["modules"].update({short_name: {"redirect": fq_module_name}})
+            plugin_routing["modules"].update(
+                {short_name: {"redirect": fq_module_name}}
+            )
 
         # handle module deprecation notice
         if "deprecated" in doc_section:
@@ -133,7 +143,7 @@ def process(collection, path):
 
     supported_ansible_versions = COLLECTION_MIN_ANSIBLE_VERSION
     if COLLECTION_MAX_ANSIBLE_VERSION:
-        supported_ansible_versions += ',' + COLLECTION_MAX_ANSIBLE_VERSION
+        supported_ansible_versions += "," + COLLECTION_MAX_ANSIBLE_VERSION
     rt_obj["requires_ansible"] = supported_ansible_versions
     plugin_routing = process_runtime_plugin_routing(collection, path)
     if plugin_routing:

--- a/collection_prep/cmd/update.py
+++ b/collection_prep/cmd/update.py
@@ -10,7 +10,11 @@ import subprocess
 import ruamel.yaml
 
 from argparse import ArgumentParser
-from collection_prep.utils import get_removed_at_date, load_py_as_ast, find_assigment_in_ast
+from collection_prep.utils import (
+    get_removed_at_date,
+    load_py_as_ast,
+    find_assigment_in_ast,
+)
 
 logging.basicConfig(format="%(levelname)-10s%(message)s", level=logging.INFO)
 
@@ -64,7 +68,9 @@ def retrieve_plugin_name(plugin_type, bodypart):
 def update_deprecation_notice(documentation):
     if "deprecated" in documentation:
         logging.info("Updating deprecation notice")
-        documentation["deprecated"].update({"removed_at_date": get_removed_at_date()})
+        documentation["deprecated"].update(
+            {"removed_at_date": get_removed_at_date()}
+        )
         documentation["deprecated"].pop("removed_in", None)
 
 
@@ -87,7 +93,9 @@ def update_documentation(bodypart):
     # remove version added
     documentation.pop("version_added", None)
     desc_idx = [
-        idx for idx, key in enumerate(documentation.keys()) if key == "description"
+        idx
+        for idx, key in enumerate(documentation.keys())
+        if key == "description"
     ]
     # insert version_added after the description
     documentation.insert(desc_idx[0] + 1, key="version_added", value="1.0.0")
@@ -115,7 +123,9 @@ def update_examples(bodypart, module_name, collection):
     full_module_name = "{collection}.{module_name}".format(
         collection=collection, module_name=module_name
     )
-    example = ruamel.yaml.load(bodypart.value.to_python(), ruamel.yaml.RoundTripLoader)
+    example = ruamel.yaml.load(
+        bodypart.value.to_python(), ruamel.yaml.RoundTripLoader
+    )
     # check each task and update to fqcn
     for idx, task in enumerate(example):
         example[idx] = ruamel.yaml.comments.CommentedMap(
@@ -150,7 +160,9 @@ def update_short_description(retrn, documentation, module_name):
     if not retrn:
         logging.warning("Failed to find RETURN assignment")
         return
-    ret_section = ruamel.yaml.load(retrn.value.to_python(), ruamel.yaml.RoundTripLoader)
+    ret_section = ruamel.yaml.load(
+        retrn.value.to_python(), ruamel.yaml.RoundTripLoader
+    )
     if not documentation:
         logging.warning("Failed to find DOCUMENTATION assignment")
         return
@@ -177,14 +189,16 @@ def update_short_description(retrn, documentation, module_name):
                 resource = "".join(chars)
             if len(parts) > 2 and parts[2] != "global":
                 resource += " {p1}".format(p1=parts[2])
-            short_description = "{resource} resource module".format(resource=resource)
+            short_description = "{resource} resource module".format(
+                resource=resource
+            )
     # Check for deprecated modules
-    if "deprecated" in doc_section and not short_description.startswith("(deprecated,"):
+    if "deprecated" in doc_section and not short_description.startswith(
+        "(deprecated,"
+    ):
         logging.info("Found to be deprecated")
         short_description = short_description.replace("(deprecated) ", "")
-        short_description = (
-            f"(deprecated, removed after {get_removed_at_date()}) {short_description}"
-        )
+        short_description = f"(deprecated, removed after {get_removed_at_date()}) {short_description}"
     # Change short if necessary
     if short_description != doc_section["short_description"]:
         logging.info("Setting short desciption to '%s'", short_description)
@@ -228,14 +242,20 @@ def process(collection, path):
                 # Get the module naem from the docstring
                 module_name = retrieve_plugin_name(
                     subdir,
-                    find_assigment_in_ast(ast_file=ast_obj, name="DOCUMENTATION"),
+                    find_assigment_in_ast(
+                        ast_file=ast_obj, name="DOCUMENTATION"
+                    ),
                 )
                 if not module_name:
-                    logging.warning("Skipped %s: No module name found", filename)
+                    logging.warning(
+                        "Skipped %s: No module name found", filename
+                    )
                     continue
 
                 # Remove the metadata
-                remove_assigment_in_ast(ast_file=ast_obj, name="ANSIBLE_METADATA")
+                remove_assigment_in_ast(
+                    ast_file=ast_obj, name="ANSIBLE_METADATA"
+                )
                 logging.info("Removed metadata in %s", filename)
 
                 # Update the documentation
@@ -249,7 +269,9 @@ def process(collection, path):
                 if subdir == "modules":
                     # Update the short description
                     update_short_description(
-                        retrn=find_assigment_in_ast(ast_file=ast_obj, name="RETURN"),
+                        retrn=find_assigment_in_ast(
+                            ast_file=ast_obj, name="RETURN"
+                        ),
                         documentation=find_assigment_in_ast(
                             ast_file=ast_obj, name="DOCUMENTATION"
                         ),

--- a/collection_prep/jinja_utils.py
+++ b/collection_prep/jinja_utils.py
@@ -20,7 +20,6 @@ _CONST = re.compile(r"C\(([^)]+)\)")
 _RULER = re.compile(r"HORIZONTALLINE")
 
 
-
 def to_kludge_ns(key, value):
     NS_MAP[key] = value
     return ""
@@ -30,10 +29,8 @@ def from_kludge_ns(key):
     return NS_MAP[key]
 
 
-
-
 def html_ify(text):
-    ''' convert symbols like I(this is in italics) to valid HTML '''
+    """ convert symbols like I(this is in italics) to valid HTML """
 
     if not isinstance(text, string_types):
         text = to_text(text)
@@ -49,8 +46,9 @@ def html_ify(text):
 
     return t.strip()
 
+
 def rst_ify(text):
-    ''' convert symbols like I(this is in italics) to valid restructured text '''
+    """ convert symbols like I(this is in italics) to valid restructured text """
 
     try:
         t = _ITALIC.sub(r"*\1*", text)
@@ -66,18 +64,17 @@ def rst_ify(text):
     return t
 
 
-
 def documented_type(text):
-    ''' Convert any python type to a type for documentation '''
+    """ Convert any python type to a type for documentation """
 
     if isinstance(text, Undefined):
-        return '-'
-    if text == 'str':
-        return 'string'
-    if text == 'bool':
-        return 'boolean'
-    if text == 'int':
-        return 'integer'
-    if text == 'dict':
-        return 'dictionary'
+        return "-"
+    if text == "str":
+        return "string"
+    if text == "bool":
+        return "boolean"
+    if text == "int":
+        return "integer"
+    if text == "dict":
+        return "dictionary"
     return text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,30 @@
-ansible==2.9.9
-ansible-base>=0.0.1a2
-appdirs==1.4.4
-astroid==2.4.1
-attrs==19.3.0
-baron==0.9
-black==19.10b0
-cffi==1.14.0
-click==7.1.2
-cryptography==2.9.2
-isort==4.3.21
-Jinja2==2.11.2
-lazy-object-proxy==1.4.3
-MarkupSafe==1.1.1
-mccabe==0.6.1
-pathspec==0.8.0
-pycparser==2.20
-pylint==2.5.2
-PyYAML==5.3.1
-pbr
-redbaron==0.9.2
-regex==2020.5.7
-rply==0.7.7
-ruamel.yaml==0.16.10
-ruamel.yaml.clib==0.2.0
-six==1.14.0
-toml==0.10.0
-typed-ast==1.4.1
-wrapt==1.12.1
+ansible>=2.10
+redbaron
+ruamel.yaml
+# appdirs==1.4.4
+# astroid==2.4.1
+# attrs==19.3.0
+# baron==0.9
+# black==19.10b0
+# cffi==1.14.0
+# click==7.1.2
+# cryptography==2.9.2
+# isort==4.3.21
+# Jinja2==2.11.2
+# lazy-object-proxy==1.4.3
+# MarkupSafe==1.1.1
+# mccabe==0.6.1
+# pathspec==0.8.0
+# pycparser==2.20
+# pylint==2.5.2
+# PyYAML==5.3.1
+# pbr
+# redbaron==0.9.2
+# regex==2020.5.7
+# rply==0.7.7
+# ruamel.yaml==0.16.10
+# ruamel.yaml.clib==0.2.0
+# six==1.14.0
+# toml==0.10.0
+# typed-ast==1.4.1
+# wrapt==1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,3 @@
 ansible>=2.10
 redbaron
 ruamel.yaml
-# appdirs==1.4.4
-# astroid==2.4.1
-# attrs==19.3.0
-# baron==0.9
-# black==19.10b0
-# cffi==1.14.0
-# click==7.1.2
-# cryptography==2.9.2
-# isort==4.3.21
-# Jinja2==2.11.2
-# lazy-object-proxy==1.4.3
-# MarkupSafe==1.1.1
-# mccabe==0.6.1
-# pathspec==0.8.0
-# pycparser==2.20
-# pylint==2.5.2
-# PyYAML==5.3.1
-# pbr
-# redbaron==0.9.2
-# regex==2020.5.7
-# rply==0.7.7
-# ruamel.yaml==0.16.10
-# ruamel.yaml.clib==0.2.0
-# six==1.14.0
-# toml==0.10.0
-# typed-ast==1.4.1
-# wrapt==1.12.1

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
 import setuptools
 
-setuptools.setup(
-    setup_requires=['pbr'],
-    pbr=True)
+setuptools.setup(setup_requires=["pbr"], pbr=True)


### PR DESCRIPTION
This adds support for any plugin that has a DOCUMENTATION string in it's file.  
We will check for that first and build an RST file.
This allow for each filter plugin to be in it's own file and has a DOC string.

Also ran the latest version of black and cleaned up the requirements file