### PR TITLE
Fix up version added for return value in plugin template

### DIFF
--- a/collection_prep/cmd/plugin.rst.j2
+++ b/collection_prep/cmd/plugin.rst.j2
@@ -379,7 +379,9 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                        / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>
                       {% endif %}
                     </div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
+{% if value.version_added %}
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>
+{% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>


### PR DESCRIPTION
The indentation was broken for any return value with the `version_added` field. An example was on the `ansible.windows` win_environment module that was changed to https://github.com/ansible-collections/ansible.windows/commit/b8bdc06f817913d025cdaa7c65dad0af55d1d4fe#diff-cdd7d9bbe1aea346b11bcc4076ce696466692aba3d67b543c312e4f4ffa5c9f6.

The doc looked like the following because the div wasn't indented

![image](https://user-images.githubusercontent.com/8462645/114624365-eb15ea00-9cf3-11eb-965e-8e6b31a2e264.png)

This fixes up the indentation so now it aligns with the cell contents.