### PR TITLE
ast.Str does not have value param

### DIFF
--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -269,7 +269,7 @@ def handle_simple(collection, fullpath, kind):
     if not simple_map:
         return plugins
 
-    keys = [k.value for k in simple_map.value.keys]
+    keys = [k.s for k in simple_map.value.keys]
     logging.info("Adding %s plugins %s", kind, ",".join(keys))
     values = [k.id for k in simple_map.value.values]
     simple_map = dict(zip(keys, values))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible>=2.10
+ansible-core
 redbaron
 ruamel.yaml


### PR DESCRIPTION
Python < 3.7 uses ast.Str instead of ast.Constant, and the Str objects have a slightly different set of properties as well. This should support all versions of Python collection_prep supports