### PR TITLE
AnsibleMapping does not work with dot syntax in newer versions of jinja2

### DIFF
--- a/collection_prep/cmd/plugin.rst.j2
+++ b/collection_prep/cmd/plugin.rst.j2
@@ -153,7 +153,7 @@ Parameters
                         </ul>
                     {% endif %}
                     {# Show default value, when multiple choice or no choices #}
-                    {% if value.default is defined and value.default not in value.choices %}
+                    {% if value['default'] is defined and value['default'] not in value.get('choices', []) %}
                         <b>Default:</b><br/><div style="color: blue">@{ value.default | tojson | escape }@</div>
                     {% endif %}
                 </td>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core
+ansible>=2.10
 redbaron
 ruamel.yaml


### PR DESCRIPTION
I imagine there _must_ be other instances where this substitution has to be made, but this one fixes the issue at hand

Fixes #58