### PR TITLE
Correctly render `removed_at_date`

### DIFF
--- a/collection_prep/cmd/plugin.rst.j2
+++ b/collection_prep/cmd/plugin.rst.j2
@@ -421,7 +421,11 @@ Status
 
 {% if deprecated %}
 
-- This @{ plugin_type }@ will be removed in version @{ deprecated['removed_in'] | default('') | string | rst_ify }@. *[deprecated]*
+{% if 'removed_in' in deprecated %}
+- This @{ plugin_type }@ will be removed in version @{ deprecated['removed_in'] | string | rst_ify }@. *[deprecated]*
+{% elif 'removed_at_date' in deprecated %}
+- This @{ plugin_type }@ will be removed in a release after @{ deprecated['removed_at_date'] | string | rst_ify }@. *[deprecated]*
+{% endif %}
 - For more information see `DEPRECATED`_.
 
 {% endif %}


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

When a plugin deprecation section has a `remove_at_date` (instead of `removed_in`), the RST was rendered as follows:
```
- This module will be removed in version . *[deprecated]*
```
This patch changes it to:

```
- This module will be removed in a release after 2022-06-01. *[deprecated]*
```