### PR TITLE
add_docs: only purge rst files from docs dir

### DIFF
--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -303,7 +303,7 @@ def process(collection, path):  # pylint: disable-msg=too-many-locals
     template = jinja_environment()
     docs_path = Path(path, "docs")
     if docs_path.is_dir():
-        logging.info("Purging existning rst files from directory %s", docs_path)
+        logging.info("Purging existing rst files from directory %s", docs_path)
         for entry in docs_path.glob("*.rst"):
             entry.unlink()
     logging.info("Making docs directory %s", docs_path)

--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -303,8 +303,9 @@ def process(collection, path):  # pylint: disable-msg=too-many-locals
     template = jinja_environment()
     docs_path = Path(path, "docs")
     if docs_path.is_dir():
-        logging.info("Purging content from directory %s", docs_path)
-        shutil.rmtree(docs_path)
+        logging.info("Purging existning rst files from directory %s", docs_path)
+        for entry in docs_path.glob("*.rst"):
+            entry.unlink()
     logging.info("Making docs directory %s", docs_path)
     Path(docs_path).mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
The docs/docsite/rst may be used to store the user manual. We want
to preserve the directory.

See: https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_structure.html#docs-directory

Closes: https://github.com/ansible-collections/community.vmware/issues/1003
Closes: https://github.com/ansible-network/collection_prep/issues/64