### PR TITLE
Fix version_added

### DIFF
--- a/collection_prep/cmd/update.py
+++ b/collection_prep/cmd/update.py
@@ -91,14 +91,17 @@ def update_documentation(bodypart):
     update_deprecation_notice(documentation)
 
     # remove version added
-    version_added = documentation.pop("version_added", "1.0.0")
-    desc_idx = [
-        idx
-        for idx, key in enumerate(documentation.keys())
-        if key == "description"
-    ]
-    # insert version_added after the description
-    documentation.insert(desc_idx[0] + 1, key="version_added", value=version_added)
+    version_added = documentation.pop("version_added", None)
+    if version_added is not None:
+        desc_idx = [
+            idx
+            for idx, key in enumerate(documentation.keys())
+            if key == "description"
+        ]
+        # insert version_added after the description
+        documentation.insert(desc_idx[0] + 1, key="version_added", value=version_added)
+    else:
+        logging.warning("Field 'version_added' not found.")
     repl = ruamel.yaml.dump(documentation, None, ruamel.yaml.RoundTripDumper)
 
     # remove version added from anywhere else in the docstring if preceded by 1+ spaces


### PR DESCRIPTION
I was observing that collection_prep took the field `version_added` from the modules doc-string and replaced whatever was written in `version_added` with `1.0.0`. 

I don't understand very much what's going on in collection_prep but it was very unexpected that collection_prep did not only produced unexpected results but changed the actual module doc-string as well. I would expect collection_prep to leave the module docstring untouched. 