### PR TITLE
Fix rstlint error when using version_added in return blocks

### DIFF
--- a/collection_prep/cmd/plugin.rst.j2
+++ b/collection_prep/cmd/plugin.rst.j2
@@ -379,7 +379,9 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                        / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>
                       {% endif %}
                     </div>
-                    {% if value.version_added %}<div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>{% endif %}
+                    {% if value.version_added %}
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in @{value.version_added}@</div>
+                    {% endif %}
                 </td>
                 <td>@{ value.returned | html_ify }@</td>
                 <td>


### PR DESCRIPTION
eg.
```
ERROR: docs/amazon.aws.ec2_eni_info_module.rst:481:0: Explicit markup ends without a blank line; unexpected unindent
```

https://dashboard.zuul.ansible.com/t/ansible/build/b1b48ab6b29244849803f43781e05674/log/job-output.txt