### PR TITLE
Change link-collection arg to be a flag instead

### DIFF
--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -530,7 +530,7 @@ def main():
     parser.add_argument(
         "--link-collection",
         dest="link_collection",
-        default=False,
+        action="store_true",
         help="Link the collection in ~/.ansible/collections",
     )
 


### PR DESCRIPTION
`--link-collection true` is a pretty surprising way to specify what is used as a flag, especially as `--link-collection false` and `--link-collection "maybe?"` also do the same thing. This changes the argument to be an actual flag and drop the unnecessary parameter