### PR TITLE
ensure we pass a str to get_docstring(), not a Path

### DIFF
--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -339,7 +339,7 @@ def process(
                         examples,
                         returndocs,
                         metadata,
-                    ) = plugin_docs.get_docstring(fullpath, fragment_loader)
+                    ) = plugin_docs.get_docstring(str(fullpath), fragment_loader)
                     if doc is None and subdir in ["filter", "test"]:
                         name_only = filename.rsplit(".")[0]
                         combined_ptype = "%s %s" % (name_only, subdir)


### PR DESCRIPTION
This to avoid the following error with recent Ansible:

```
Traceback (most recent call last):
  File "/venv/add_docs/bin/collection_prep_add_docs", line 8, in <module>
    sys.exit(main())
  File "/venv/add_docs/lib/python3.10/site-packages/collection_prep/cmd/add_docs.py", line 604, in main
    content = process(collection=collection, path=path)
  File "/venv/add_docs/lib/python3.10/site-packages/collection_prep/cmd/add_docs.py", line 342, in process
    ) = plugin_docs.get_docstring(fullpath, fragment_loader)
  File "/venv/add_docs/lib/python3.10/site-packages/ansible/utils/plugin_docs.py", line 222, in get_docstring
    data = read_docstring(filename, verbose=verbose, ignore_errors=ignore_errors)
  File "/venv/add_docs/lib/python3.10/site-packages/ansible/parsing/plugin_docs.py", line 175, in read_docstring
    if filename.endswith(C.YAML_DOC_EXTENSIONS):
AttributeError: 'PosixPath' object has no attribute 'endswith'
```
