### PR TITLE
Replace str with to_text()

### DIFF
--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -333,14 +333,14 @@ def process(
             logging.info("Process content in %s", dirpath)
             for filename in os.listdir(dirpath):
                 if filename.endswith(".py") and filename not in IGNORE_FILES:
-                    fullpath = to_text(Path(dirpath, filename))
+                    fullpath = Path(dirpath, filename)
                     logging.info("Processing %s", fullpath)
                     (
                         doc,
                         examples,
                         returndocs,
                         metadata,
-                    ) = plugin_docs.get_docstring(fullpath, fragment_loader)
+                    ) = plugin_docs.get_docstring(to_text(fullpath), fragment_loader)
                     if doc is None and subdir in ["filter", "test"]:
                         name_only = filename.rsplit(".")[0]
                         combined_ptype = "%s %s" % (name_only, subdir)

--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -332,7 +332,7 @@ def process(
             logging.info("Process content in %s", dirpath)
             for filename in os.listdir(dirpath):
                 if filename.endswith(".py") and filename not in IGNORE_FILES:
-                    fullpath = Path(dirpath, filename)
+                    fullpath = str(Path(dirpath, filename))
                     logging.info("Processing %s", fullpath)
                     (
                         doc,

--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -333,14 +333,14 @@ def process(
             logging.info("Process content in %s", dirpath)
             for filename in os.listdir(dirpath):
                 if filename.endswith(".py") and filename not in IGNORE_FILES:
-                    fullpath = str(Path(dirpath, filename))
+                    fullpath = to_text(Path(dirpath, filename))
                     logging.info("Processing %s", fullpath)
                     (
                         doc,
                         examples,
                         returndocs,
                         metadata,
-                    ) = plugin_docs.get_docstring(to_text(fullpath), fragment_loader)
+                    ) = plugin_docs.get_docstring(fullpath, fragment_loader)
                     if doc is None and subdir in ["filter", "test"]:
                         name_only = filename.rsplit(".")[0]
                         combined_ptype = "%s %s" % (name_only, subdir)

--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 import yaml
 from ansible.module_utils.common.collections import is_sequence
+from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs
@@ -339,7 +340,7 @@ def process(
                         examples,
                         returndocs,
                         metadata,
-                    ) = plugin_docs.get_docstring(str(fullpath), fragment_loader)
+                    ) = plugin_docs.get_docstring(to_text(fullpath), fragment_loader)
                     if doc is None and subdir in ["filter", "test"]:
                         name_only = filename.rsplit(".")[0]
                         combined_ptype = "%s %s" % (name_only, subdir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core>=2.14
+ansible-core
 redbaron
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core<2.14
+ansible-core>=2.14
 redbaron
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core
+ansible-core<2.14
 redbaron
 ruamel.yaml


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

With core 2.14.0, collection_prep_add_docs fails with the following traceback. This patch sends a string instead of PosixPath to plugin_docs and pins the ansible-core version in requirements.txt.
```
Traceback (most recent call last):
  File "/home/nchakrab/.virtualenvs/prep/bin/collection_prep_add_docs", line 8, in <module>
    sys.exit(main())
  File "/home/nchakrab/.virtualenvs/prep/lib/python3.10/site-packages/collection_prep/cmd/add_docs.py", line 604, in main
    content = process(collection=collection, path=path)
  File "/home/nchakrab/.virtualenvs/prep/lib/python3.10/site-packages/collection_prep/cmd/add_docs.py", line 342, in process
    ) = plugin_docs.get_docstring(fullpath, fragment_loader)
  File "/home/nchakrab/.virtualenvs/prep/lib/python3.10/site-packages/ansible/utils/plugin_docs.py", line 222, in get_docstring
    data = read_docstring(filename, verbose=verbose, ignore_errors=ignore_errors)
  File "/home/nchakrab/.virtualenvs/prep/lib/python3.10/site-packages/ansible/parsing/plugin_docs.py", line 175, in read_docstring
    if filename.endswith(C.YAML_DOC_EXTENSIONS):
AttributeError: 'PosixPath' object has no attribute 'endswith'
```