### PR TITLE
Use antsibull-docs-parser to render semantic markup

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -22,6 +22,7 @@ nthhost
 ospfv
 slaac
 # Python packages
+antsibull
 argcomplete
 redbaron
 ruamel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,7 @@ repos:
       - id: pylint
         additional_dependencies:
           - ansible-core
+          - antsibull-docs-parser
           - pyyaml
           - redbaron
           - ruamel.yaml

--- a/collection_prep/jinja_utils.py
+++ b/collection_prep/jinja_utils.py
@@ -1,22 +1,18 @@
 """Utilities for jinja2."""
-import re
 
-from html import escape as html_escape
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
+from antsibull_docs_parser import dom
+from antsibull_docs_parser.html import to_html_plain
+from antsibull_docs_parser.parser import Context
+from antsibull_docs_parser.parser import parse
+from antsibull_docs_parser.rst import to_rst_plain
 from jinja2.runtime import Undefined
+from jinja2.utils import pass_context
 
 
 NS_MAP = {}
-
-_ITALIC = re.compile(r"I\(([^)]+)\)")
-_BOLD = re.compile(r"B\(([^)]+)\)")
-_MODULE = re.compile(r"M\(([^)]+)\)")
-_URL = re.compile(r"U\(([^)]+)\)")
-_LINK = re.compile(r"L\(([^)]+), *([^)]+)\)")
-_CONST = re.compile(r"C\(([^)]+)\)")
-_RULER = re.compile(r"HORIZONTALLINE")
 
 
 def to_kludge_ns(key, value):
@@ -39,40 +35,50 @@ def from_kludge_ns(key):
     return NS_MAP[key]
 
 
-def html_ify(text):
+def get_context(j2_context):
+    """Create parser context from Jinja2 context.
+
+    :param j2_context: The Jinja2 context
+    :return: A parser context
+    """
+    params = {}
+    plugin_fqcn = j2_context.get("module")
+    plugin_type = j2_context.get("plugin_type")
+    if plugin_fqcn is not None and plugin_type is not None:
+        params["current_plugin"] = dom.PluginIdentifier(fqcn=plugin_fqcn, type=plugin_type)
+    return Context(**params)
+
+
+@pass_context
+def html_ify(j2_context, text):
     """Convert symbols like I(this is in italics) to valid HTML.
 
+    :param j2_context: The Jinja2 context
     :param text: The text to transform
     :return: An HTML string of the formatted text
     """
     if not isinstance(text, string_types):
         text = to_text(text)
 
-    text = html_escape(text)
-    text = _ITALIC.sub(r"<em>\1</em>", text)
-    text = _BOLD.sub(r"<b>\1</b>", text)
-    text = _MODULE.sub(r"<span class='module'>\1</span>", text)
-    text = _URL.sub(r"<a href='\1'>\1</a>", text)
-    text = _LINK.sub(r"<a href='\2'>\1</a>", text)
-    text = _CONST.sub(r"<code>\1</code>", text)
-    text = _RULER.sub(r"<hr/>", text)
+    paragraphs = parse(text, get_context(j2_context))
+    text = to_html_plain(paragraphs, par_start="", par_end="")
 
     return text.strip()
 
 
-def rst_ify(text):
+@pass_context
+def rst_ify(j2_context, text):
     """Convert symbols like I(this is in italics) to valid restructured text.
 
+    :param j2_context: The Jinja2 context
     :param text: The text to transform
     :return: An RST string of the formatted text
     """
-    text = _ITALIC.sub(r"*\1*", text)
-    text = _BOLD.sub(r"**\1**", text)
-    text = _MODULE.sub(r":ref:`\1 <\1_module>`", text)
-    text = _LINK.sub(r"`\1 <\2>`_", text)
-    text = _URL.sub(r"\1", text)
-    text = _CONST.sub(r"``\1``", text)
-    text = _RULER.sub(r"------------", text)
+    if not isinstance(text, string_types):
+        text = to_text(text)
+
+    paragraphs = parse(text, get_context(j2_context))
+    text = to_rst_plain(paragraphs)
 
     return text
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible-core
 redbaron
 ruamel.yaml
+antsibull-docs-parser >= 1.0.0, < 2.0.0


### PR DESCRIPTION
Uses the Python library [antsibull-docs-parser](https://pypi.org/project/antsibull-docs-parser/) (https://github.com/ansible-community/antsibull-docs-parser) to render Ansible markup, including the new semantic markup.

The plain RST created by antsibull-docs-parser is slightly different from the one created by the original code:
```diff
diff -r docs.orig/community.dns.hetzner_dns_record_module.rst docs/community.dns.hetzner_dns_record_module.rst
21c21
< - If you do not want to add/remove values, but replace values, you will be interested in modifying a **record set** and not a single record. This is in particular important when working with ``CNAME`` and ``SOA`` records. Use the :ref:`community.dns.hetzner_dns_record_set <community.dns.hetzner_dns_record_set_module>` module for working with record sets.
---
> - If you do not want to add/remove values, but replace values, you will be interested in modifying a \ :strong:`record set`\  and not a single record. This is in particular important when working with \ :literal:`CNAME`\  and \ :literal:`SOA`\  records. Use the \ :ref:`community.dns.hetzner\_dns\_record\_set <ansible_collections.community.dns.hetzner_dns_record_set_module>`\  module for working with record sets.
diff -r docs.orig/community.dns.hetzner_dns_record_sets_module.rst docs/community.dns.hetzner_dns_record_sets_module.rst
21c21
< - It is possible to ignore certain record sets by specifying *ignore: true* for that record set.
---
> - It is possible to ignore certain record sets by specifying \ :emphasis:`ignore: true`\  for that record set.
23c23
< - With the *purge* option, it is also possible to delete existing record sets that are not mentioned in the module parameters. With this, it is possible to synchronize the expected state of a DNS zone with the expected state.
---
> - With the \ :emphasis:`purge`\  option, it is also possible to delete existing record sets that are not mentioned in the module parameters. With this, it is possible to synchronize the expected state of a DNS zone with the expected state.
diff -r docs.orig/community.dns.hetzner_dns_records_inventory.rst docs/community.dns.hetzner_dns_records_inventory.rst
20c20
< - For Ansible to be able to identify a YAML file as an inventory for this plugin, the inventory file must contain ``plugin: community.dns.hetzner_dns_records`` and its filename must end with ``hetzner_dns.yaml`` or ``hetzner_dns.yml``
---
> - For Ansible to be able to identify a YAML file as an inventory for this plugin, the inventory file must contain \ :literal:`plugin: community.dns.hetzner\_dns\_records`\  and its filename must end with \ :literal:`hetzner\_dns.yaml`\  or \ :literal:`hetzner\_dns.yml`\ 
230,231c230,231
<    - The provider-specific *hetzner_token* option can be templated.
<    - The *zone_name* and *zone_id* options can be templated.
---
>    - The provider-specific \ :emphasis:`hetzner\_token`\  option can be templated.
>    - The \ :emphasis:`zone\_name`\  and \ :emphasis:`zone\_id`\  options can be templated.
diff -r docs.orig/community.dns.hosttech_dns_record_module.rst docs/community.dns.hosttech_dns_record_module.rst
21c21
< - If you do not want to add/remove values, but replace values, you will be interested in modifying a **record set** and not a single record. This is in particular important when working with ``CNAME`` and ``SOA`` records. Use the :ref:`community.dns.hosttech_dns_record_set <community.dns.hosttech_dns_record_set_module>` module for working with record sets.
---
> - If you do not want to add/remove values, but replace values, you will be interested in modifying a \ :strong:`record set`\  and not a single record. This is in particular important when working with \ :literal:`CNAME`\  and \ :literal:`SOA`\  records. Use the \ :ref:`community.dns.hosttech\_dns\_record\_set <ansible_collections.community.dns.hosttech_dns_record_set_module>`\  module for working with record sets.
23c23
< - This module replaces ``hosttech_dns_record`` from community.dns before 2.0.0.
---
> - This module replaces \ :literal:`hosttech\_dns\_record`\  from community.dns before 2.0.0.
diff -r docs.orig/community.dns.hosttech_dns_record_set_info_module.rst docs/community.dns.hosttech_dns_record_set_info_module.rst
21c21
< - This module was renamed from ``community.dns.hosttech_dns_record_info`` to ``community.dns.hosttech_dns_record_set_info`` in community.dns 2.0.0.
---
> - This module was renamed from \ :literal:`community.dns.hosttech\_dns\_record\_info`\  to \ :literal:`community.dns.hosttech\_dns\_record\_set\_info`\  in community.dns 2.0.0.
diff -r docs.orig/community.dns.hosttech_dns_record_set_module.rst docs/community.dns.hosttech_dns_record_set_module.rst
21c21
< - This module replaces ``hosttech_dns_record`` from community.dns before 2.0.0.
---
> - This module replaces \ :literal:`hosttech\_dns\_record`\  from community.dns before 2.0.0.
diff -r docs.orig/community.dns.hosttech_dns_record_sets_module.rst docs/community.dns.hosttech_dns_record_sets_module.rst
21c21
< - It is possible to ignore certain record sets by specifying *ignore: true* for that record set.
---
> - It is possible to ignore certain record sets by specifying \ :emphasis:`ignore: true`\  for that record set.
23,24c23,24
< - This module replaces ``hosttech_dns_records`` from community.dns before 2.0.0.
< - With the *purge* option, it is also possible to delete existing record sets that are not mentioned in the module parameters. With this, it is possible to synchronize the expected state of a DNS zone with the expected state.
---
> - This module replaces \ :literal:`hosttech\_dns\_records`\  from community.dns before 2.0.0.
> - With the \ :emphasis:`purge`\  option, it is also possible to delete existing record sets that are not mentioned in the module parameters. With this, it is possible to synchronize the expected state of a DNS zone with the expected state.
diff -r docs.orig/community.dns.hosttech_dns_records_inventory.rst docs/community.dns.hosttech_dns_records_inventory.rst
20c20
< - For Ansible to be able to identify a YAML file as an inventory for this plugin, the inventory file must contain ``plugin: community.dns.hosttech_dns_records`` and its filename must end with ``hosttech_dns.yaml`` or ``hosttech_dns.yml``
---
> - For Ansible to be able to identify a YAML file as an inventory for this plugin, the inventory file must contain \ :literal:`plugin: community.dns.hosttech\_dns\_records`\  and its filename must end with \ :literal:`hosttech\_dns.yaml`\  or \ :literal:`hosttech\_dns.yml`\ 
273,274c273,274
<    - The provider-specific *hosttech_username*, *hosttech_password*, and *hosttech_token* options can be templated.
<    - The *zone_name* and *zone_id* options can be templated.
---
>    - The provider-specific \ :emphasis:`hosttech\_username`\ , \ :emphasis:`hosttech\_password`\ , and \ :emphasis:`hosttech\_token`\  options can be templated.
>    - The \ :emphasis:`zone\_name`\  and \ :emphasis:`zone\_id`\  options can be templated.
diff -r docs.orig/community.dns.wait_for_txt_module.rst docs/community.dns.wait_for_txt_module.rst
20c20
< - Wait for TXT entries with specific values to show up on **all** authoritative nameservers for the DNS name.
---
> - Wait for TXT entries with specific values to show up on \ :strong:`all`\  authoritative nameservers for the DNS name.
28c28
< - dnspython >= 1.15.0 (maybe older versions also work)
---
> - dnspython \>= 1.15.0 (maybe older versions also work)
```
This are the docs generated from the community.dns collection.

(I marked this as a draft since I want to wait a bit until antsibull-docs-parser reaches 1.0.0 before making this ready.)