### PR TITLE
Fix ansible-core version as it works in 2.16

### DIFF
--- a/collection_prep/cmd/runtime.py
+++ b/collection_prep/cmd/runtime.py
@@ -14,8 +14,8 @@ from collection_prep.utils import load_py_as_ast
 
 logging.basicConfig(format="%(levelname)-10s%(message)s", level=logging.INFO)
 
-COLLECTION_MIN_ANSIBLE_VERSION = ">=2.9.10"
-COLLECTION_MAX_ANSIBLE_VERSION = "<2.11"
+COLLECTION_MIN_ANSIBLE_VERSION = ">=2.14.10"
+COLLECTION_MAX_ANSIBLE_VERSION = "<2.19"
 DEPRECATION_CYCLE_IN_YEAR = 2
 REMOVAL_FREQUENCY_IN_MONTHS = 3
 REMOVAL_DAY_OF_MONTH = "01"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core
+ansible-core==2.16
 redbaron
 ruamel.yaml


### PR DESCRIPTION
Note - This unblocks CI but there needs to be some fixes to address ansible-core versions post 2.16