### PR TITLE
add_docs: Fix #94 to_text exception (unsupported type <class 'pathlib.PosixPath'>)

### DIFF
--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -17,7 +17,11 @@ from typing import Optional
 
 import yaml
 
-from ansible.module_utils._text import to_text
+
+try:
+    from ansible.module_utils.common.text.converters import to_text
+except ImportError:
+    from ansible.module_utils._text import to_text
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import string_types
 from ansible.plugins.loader import fragment_loader
@@ -462,7 +466,7 @@ def add_collection(path: Path, galaxy: dict) -> Optional[tempfile.TemporaryDirec
 
     # Tell ansible about the path
     _AnsibleCollectionFinder(  # pylint: disable-msg=protected-access
-        paths=[collections_path, "~/.ansible/collections"]
+        paths=[to_text(collections_path), "~/.ansible/collections"]
     )._install()
 
     # This object has to outlive this method or it will be cleaned up before


### PR DESCRIPTION
This fixes the following error[^1] when running `collection_prep_add_docs -p path/to/a_collection`:

```console
$ collection_prep_add_docs -p ./

[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: DEFAULT_MANAGED_STR option. Reason: The `ansible_managed` variable can be set just like any other variable, or a different variable can be used.
Alternatives: Set the `ansible_managed` variable, or use any custom variable in templates. This feature will be removed from ansible-core version 2.23.

[DEPRECATION WARNING]: Importing 'to_text' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
INFO      Setting collection name to example.collection
INFO      Setting GitHub repository url to https://github.com/example/ansible_example_collection
INFO      Collection path is /home/exampleuser/src/pub/ansible/ansible_example_collection
Traceback (most recent call last):
  File "/usr/local/bin/collection_prep_add_docs", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/site-packages/collection_prep/cmd/add_docs.py", line 546, in main
    tempdir = add_collection(path, galaxy)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/collection_prep/cmd/add_docs.py", line 464, in add_collection
    _AnsibleCollectionFinder(  # pylint: disable-msg=protected-access
  File "/usr/local/lib/python3.12/site-packages/ansible/utils/collection_loader/_collection_finder.py", line 195, in __init__
    paths = [os.path.expanduser(_to_text(p)) for p in paths]
                                ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/ansible/utils/collection_loader/__init__.py", line 37, in _to_text
    raise TypeError(f'unsupported type {type(value)}')
TypeError: unsupported type <class 'pathlib.PosixPath'>
```

[^1]: **Note:** Ansible core `_AnsibleCollectionFinder` code still uses deprecated internal `_to_text` method (as of Ansible `2.20.0`), which does not handle `pathlib.PosixPath`.  Meanwhile, `to_text` from `ansible.module_utils.common.text.converters` now does.  Therefore, we can convert to text here using the public `to_text` import if available in newer Ansible versions, else fall back to the old import.