### PR TITLE
Update pre-commit hooks to current releases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 ---
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.261"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.16.3"
     hooks:
-      - id: ruff
+      - id: ruff-check
         args:
           - "--fix"
           - "--exit-non-zero-on-fix"
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.0-alpha.6"
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.9.6
     hooks:
       - id: prettier
         additional_dependencies:
@@ -17,23 +17,23 @@ repos:
           - prettier-plugin-toml
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 26.5.1
     hooks:
       - id: black
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v6.31.0
+    rev: v10.0.1
     hooks:
       - id: cspell
         name: Spell check with cspell
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.4.2
+    rev: v1.5.6
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-symlinks
@@ -44,12 +44,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.4.3
     hooks:
       - id: codespell
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.30.0
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args:
@@ -61,8 +61,8 @@ repos:
     hooks:
       - id: darglint
 
-  - repo: https://github.com/pycqa/pylint
-    rev: v2.17.1
+  - repo: https://github.com/pylint-dev/pylint
+    rev: v4.0.7
     hooks:
       - id: pylint
         additional_dependencies:
@@ -70,3 +70,4 @@ repos:
           - pyyaml
           - redbaron
           - ruamel.yaml
+          - setuptools

--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -17,8 +17,8 @@ from typing import Optional
 
 import yaml
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.collections import is_sequence
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six import string_types
 from ansible.plugins.loader import fragment_loader
 from ansible.utils import plugin_docs

--- a/collection_prep/cmd/add_docs.py
+++ b/collection_prep/cmd/add_docs.py
@@ -2,6 +2,7 @@
 # PYTHON_ARGCOMPLETE_OK
 
 """Generate or update collection documentation."""
+
 import ast
 import logging
 import os
@@ -31,7 +32,6 @@ from collection_prep.jinja_utils import from_kludge_ns
 from collection_prep.jinja_utils import html_ify
 from collection_prep.jinja_utils import rst_ify
 from collection_prep.jinja_utils import to_kludge_ns
-
 
 try:
     import argcomplete

--- a/collection_prep/cmd/runtime.py
+++ b/collection_prep/cmd/runtime.py
@@ -1,4 +1,5 @@
 """Get ready for 1.0.0."""
+
 import glob
 import logging
 import os
@@ -10,7 +11,6 @@ import ruamel.yaml
 from collection_prep.utils import find_assignment_in_ast
 from collection_prep.utils import get_removed_at_date
 from collection_prep.utils import load_py_as_ast
-
 
 logging.basicConfig(format="%(levelname)-10s%(message)s", level=logging.INFO)
 

--- a/collection_prep/cmd/update.py
+++ b/collection_prep/cmd/update.py
@@ -1,4 +1,5 @@
 """Get ready for 1.0.0."""
+
 import logging
 import os
 import platform
@@ -13,7 +14,6 @@ import ruamel.yaml
 from collection_prep.utils import find_assignment_in_ast
 from collection_prep.utils import get_removed_at_date
 from collection_prep.utils import load_py_as_ast
-
 
 logging.basicConfig(format="%(levelname)-10s%(message)s", level=logging.INFO)
 

--- a/collection_prep/cmd/version.py
+++ b/collection_prep/cmd/version.py
@@ -1,4 +1,5 @@
 """Script to guess the next version of an ansible collection."""
+
 import logging
 import sys
 
@@ -6,7 +7,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 import ruamel.yaml
-
 
 yaml = ruamel.yaml.YAML()
 # Preserve document layout

--- a/collection_prep/jinja_utils.py
+++ b/collection_prep/jinja_utils.py
@@ -1,4 +1,5 @@
 """Utilities for jinja2."""
+
 import re
 
 from html import escape as html_escape
@@ -6,7 +7,6 @@ from html import escape as html_escape
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six import string_types
 from jinja2.runtime import Undefined
-
 
 NS_MAP = {}
 

--- a/collection_prep/jinja_utils.py
+++ b/collection_prep/jinja_utils.py
@@ -3,7 +3,7 @@ import re
 
 from html import escape as html_escape
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six import string_types
 from jinja2.runtime import Undefined
 

--- a/collection_prep/utils.py
+++ b/collection_prep/utils.py
@@ -1,8 +1,8 @@
 """Get ready for 1.0.0."""
+
 import datetime
 
 from redbaron import RedBaron
-
 
 COLLECTION_MIN_ANSIBLE_VERSION = ">=2.9"
 DEPRECATION_CYCLE_IN_YEAR = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ max-line-length = 100
 
 [tool.pylint.master]
 no-docstring-rgx = "__.*__"
+# ruamel.yaml's deprecated top-level load/dump helpers are typed as returning
+# None, which makes pylint emit spurious no-return/unsubscriptable errors on the
+# parsed results. Skip member inference for the package to avoid the noise.
+ignored-modules = ["ruamel.yaml"]
 
 [tool.pylint.messages_control]
 disable = ["duplicate-code", "fixme"]
@@ -18,6 +22,10 @@ enable = [
 
 [tool.ruff]
 line-length = 100
+builtins = ["_"]
+target-version = "py39"
+
+[tool.ruff.lint]
 select = [
   "D", # pydocstyle
   "E", # pycodestyle
@@ -28,16 +36,14 @@ select = [
   "YTT", # flake8-2020
 
 ]
-builtins = ["_"]
-target-version = "py39"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true # Force from .. import to be 1 per line, minimizing changes at time of implementation
-lines-after-imports = 2 # Ensures consistency for cases when there's variable vs function/class definitions after imports
+lines-after-imports = -1 # Let ruff match black: 2 blank lines before a def/class, 1 before a plain statement
 lines-between-types = 1 # Separate import/from with 1 line, minimizing changes at time of implementation
 no-lines-before = [
   "local-folder"
 ] # Keeps local imports bundled with first-party
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,4 @@
 
 import setuptools
 
-
 setuptools.setup(setup_requires=["pbr"], pbr=True)


### PR DESCRIPTION
Every hook in `.pre-commit-config.yaml` was pinned to early-2023 versions. The `pylint` hook could no longer install under Python 3.12 — its build pulled an old `setuptools` that references the removed `pkgutil.ImpImporter` — which blocked commits entirely. This updates all hooks to their current releases and adapts the config so the full suite passes.

### Hook updates

| Hook | Before | After | Note |
|---|---|---|---|
| ruff | `charliermarsh/ruff-pre-commit` v0.0.261 (`ruff`) | `astral-sh/ruff-pre-commit` v0.16.3 (`ruff-check`) | repo moved, hook renamed |
| prettier | `pre-commit/mirrors-prettier` v3.0.0-alpha.6 | `rbubley/mirrors-prettier` v3.9.6 | upstream archived; switched to maintained fork |
| black | 23.3.0 | 26.5.1 | |
| pylint | `pycqa/pylint` v2.17.1 | `pylint-dev/pylint` v4.0.7 | **fixes the Python 3.12 install failure** |
| cspell-cli | v6.31.0 | v10.0.1 | |
| pre-commit-hooks | v4.4.0 | v6.0.0 | |
| codespell | v2.2.4 | v2.4.3 | |
| yamllint | v1.30.0 | v1.38.0 | |
| Lucas-C/pre-commit-hooks | v1.4.2 | v1.5.6 | |
| darglint | v1.8.1 | v1.8.1 | already latest (upstream unmaintained) |

### Config changes (`pyproject.toml`)

- Migrated `[tool.ruff]` `select` / `isort` / `pydocstyle` sections to the `[tool.ruff.lint]` namespace required by current ruff.
- Changed isort `lines-after-imports` from `2` to `-1` so ruff no longer fights black over blank lines after the import block (a fixed value can't match black's context-dependent rule).
- Added `ruamel.yaml` to pylint `ignored-modules` to suppress spurious `no-return` / `unsubscriptable` errors caused by ruamel's deprecated top-level `load`/`dump` helpers.
- Added `setuptools` to the pylint hook's `additional_dependencies` so `setup.py` resolves its import.

### Source changes

- `add_docs.py`, `jinja_utils.py`: import `to_text` from `ansible.module_utils.common.text.converters` instead of the deprecated `ansible.module_utils._text` shim (also clears pylint's `no-name-in-module` under v4). No behavior change.
- Reformatting across 7 files from black 26.x / ruff (blank line after the module docstring, single blank line after imports).

All 16 hooks pass on a clean run (`prek run --all-files`).

### Commits

Split for reviewability: tooling/config update → import modernization → formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)